### PR TITLE
Recast tree-sitter-node-at-point as tree-sitter-node-at-pos, adding optional POS parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 - Reduced GC pressure by not making the text property `face` a list if there is only one face.
+- Recast `tree-sitter-node-at-point` as more general `tree-sitter-node-at-pos`, taking optional POS argument.
 
 ## [0.15.1] - 2021-03-20
 - Fixed some invalid query patterns [causing SIGABRT](https://github.com/emacs-tree-sitter/elisp-tree-sitter/issues/125), by upgrading `tree-sitter` crate.

--- a/doc/emacs-tree-sitter.org
+++ b/doc/emacs-tree-sitter.org
@@ -104,7 +104,7 @@ To enable it for all supported major modes:
 
 For the full list of supported major modes, check the variable ~tree-sitter-major-mode-language-alist~.
 
-# ~tree-sitter-node-at-point~
+# ~tree-sitter-node-at-pos~
 # ~tree-sitter-save-excursion~
 
 ** Turn on Syntax Highlighting
@@ -593,14 +593,14 @@ As described in the previous section, the ~-named-~  variants of the functions i
 - ~tsc-get-nth-child~ /~node nth~/ :: <br>
 - ~tsc-get-nth-named-child~ /~node nth~/ :: Get a child node by its 0-based index (any, or named only).
     #+begin_src emacs-lisp
-      (let ((func (tree-sitter-node-at-point 'function_item)))
+      (let ((func (tree-sitter-node-at-pos 'function_item)))
         (tsc-get-nth-child func 0)        ; An "fn" node
         (tsc-get-nth-named-child func 0)) ; An 'identifier node
     #+end_src
 - ~tsc-get-child-by-field~ /~node field~/ :: Certain node types assign unique field names to specific child nodes. This function allows retrieving child nodes by their field names, instead of by their indexes. The field name should be specified as a keyword.
     #+begin_src emacs-lisp
       ;; Get name of the current function definition.
-      (let ((func (tree-sitter-node-at-point 'function_item)))
+      (let ((func (tree-sitter-node-at-pos 'function_item)))
         (tsc-node-text (tsc-get-child-by-field func :name)))
     #+end_src
     {{% notice info %}}In Tree-sitter's [[https://tree-sitter.github.io/tree-sitter/using-parsers#node-field-names][documentation]], due to the low-level nature of C and JSON, field names are specified as strings. Representing field names as keywords makes it more Lisp-idiomatic.{{% /notice %}}
@@ -671,7 +671,7 @@ TODO: Write this.
 - Variable: ~tree-sitter-major-mode-language-alist~ :: <br>
 - Variable: ~tree-sitter-language~ :: <br>
 - Variable: ~tree-sitter-tree~ :: <br>
-- Function: ~tree-sitter-node-at-point~ /~[node-type]~/ :: <br>
+- Function: ~tree-sitter-node-at-pos~ /~[node-type] [pos]~/ :: <br>
 
 ** Writing a Dependent Minor Mode
 See the docstring of ~tree-sitter--handle-dependent~.

--- a/lisp/tree-sitter-extras.el
+++ b/lisp/tree-sitter-extras.el
@@ -60,7 +60,7 @@ at roughly the same vertical screen position. If `pixel-scroll' is available and
 instead, to make this restoration exact."
   (declare (indent 0))
   `(let* ((p (point))
-          (old-node (tree-sitter-node-at-point))
+          (old-node (tree-sitter-node-at-pos))
           (steps (tsc--node-steps old-node))
           (delta (- p (tsc-node-start-position old-node)))
           (screen-line (- (count-screen-lines (window-start) p) 1))

--- a/lisp/tree-sitter-tests.el
+++ b/lisp/tree-sitter-tests.el
@@ -230,17 +230,18 @@ If RESET is non-nil, also do another full parse and check again."
 
 (ert-deftest minor-mode::node-at-point ()
   (tsc-test-lang-with-file 'rust "lisp/test-files/types.rs"
-    (should (eq 'source_file (tsc-node-type (tree-sitter-node-at-point 'source_file))))
+    (should (eq 'source_file (tsc-node-type (tree-sitter-node-at-pos 'source_file))))
+    (should (eq 'identifier (tsc-node-type (tree-sitter-node-at-pos nil 370))))
     (search-forward "erase_")
-    (should (eq 'identifier (tsc-node-type (tree-sitter-node-at-point))))
-    (should (eq 'function_item (tsc-node-type (tree-sitter-node-at-point 'function_item))))
-    (should (null (tree-sitter-node-at-point "function_item")))
-    (should (null (tree-sitter-node-at-point 'impl_item)))
+    (should (eq 'identifier (tsc-node-type (tree-sitter-node-at-pos))))
+    (should (eq 'function_item (tsc-node-type (tree-sitter-node-at-pos 'function_item))))
+    (should (null (tree-sitter-node-at-pos "function_item")))
+    (should (null (tree-sitter-node-at-pos 'impl_item)))
     ;; FIX: Signal an error for non-existing node types.
-    (should (null (tree-sitter-node-at-point 'non-existing-node-type)))
+    (should (null (tree-sitter-node-at-pos 'non-existing-node-type)))
     (search-forward "struc")
-    (should (equal "struct" (tsc-node-type (tree-sitter-node-at-point))))
-    (should (eq 'struct_item (tsc-node-type (tree-sitter-node-at-point 'struct_item))))))
+    (should (equal "struct" (tsc-node-type (tree-sitter-node-at-pos))))
+    (should (eq 'struct_item (tsc-node-type (tree-sitter-node-at-pos 'struct_item))))))
 
 (ert-deftest node::eq ()
   (tsc-test-with 'rust parser

--- a/lisp/tree-sitter.el
+++ b/lisp/tree-sitter.el
@@ -269,11 +269,15 @@ Both SETUP-FUNCTION and TEARDOWN-FUNCTION should be idempotent."
        ,teardown)))
 
 ;;;###autoload
-(defun tree-sitter-node-at-point (&optional node-type)
-  "Return the smallest syntax node at point whose type is NODE-TYPE.
-If NODE-TYPE is nil, return the smallest syntax node at point."
+(define-obsolete-function-alias 'tree-sitter-node-at-point 'tree-sitter-node-at-pos "2021-08-30")
+
+;;;###autoload
+(defun tree-sitter-node-at-pos (&optional node-type pos)
+  "Return the smallest syntax node of type NODE-TYPE at POS.
+If NODE-TYPE is nil, return the smallest syntax node at POS.
+IF POS is nil, defaults to the point."
   (let* ((root (tsc-root-node tree-sitter-tree))
-         (p (point))
+         (p (or pos (point)))
          (node (tsc-get-descendant-for-position-range root p p)))
     (if node-type
         (let ((this node) result)


### PR DESCRIPTION
You might reasonably object to adding a POS parameter to a defun named `*-at-point`.

In which case, is a `tree-sitter-node-at-pos` welcome?  My purpose is to avoid needless `save-excursion`s in the calling code.