### PR TITLE
Don't make `face` property a list if there is only one face

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
+- Reduced GC pressure by not making the text property `face` a list if there is only one face.
 
 ## [0.15.1] - 2021-03-20
 - Fixed some invalid query patterns [causing SIGABRT](https://github.com/emacs-tree-sitter/elisp-tree-sitter/issues/125), by upgrading `tree-sitter` crate.

--- a/lisp/tree-sitter-hl.el
+++ b/lisp/tree-sitter-hl.el
@@ -448,28 +448,6 @@ also expects VALUE to be a single value, not a list."
                            object))
       (setq start next))))
 
-(defun tree-sitter-hl--prepend-text-property (start end prop value &optional object)
-  "Prepend VALUE to PROP of the text from START to END.
-This is similar to `font-lock-prepend-text-property', but deduplicates values.
-It also expects VALUE to be a single value, not a list."
-  (let (next prev)
-    (while (/= start end)
-      (setq next (next-single-property-change start prop object end)
-            prev (get-text-property start prop object))
-      ;; Canonicalize old forms of face property.
-      (and (memq prop '(face font-lock-face))
-           (listp prev)
-           (or (keywordp (car prev))
-               (memq (car prev) '(foreground-color background-color)))
-           (setq prev (list prev)))
-      (unless (listp prev)
-        (setq prev (list prev)))
-      (unless (memq value prev)
-        (put-text-property start next prop
-                           (cons value prev)
-                           object))
-      (setq start next))))
-
 (defun tree-sitter-hl--highlight-capture (capture)
   "Highlight the given CAPTURE."
   (pcase-let ((`(,face . (,beg-byte . ,end-byte)) capture))

--- a/lisp/tree-sitter-hl.el
+++ b/lisp/tree-sitter-hl.el
@@ -429,7 +429,8 @@ See https://github.com/tree-sitter/tree-sitter/issues/598."
 (defun tree-sitter-hl--append-text-property (start end prop value &optional object)
   "Append VALUE to PROP of the text from START to END.
 This is similar to `font-lock-append-text-property', but deduplicates values. It
-also expects VALUE to be a single value, not a list."
+also expects VALUE to be a single value, not a list. Additionally, if PROP was
+previously nil, it will be set to VALUE, not (list VALUE)."
   (let (next prev)
     (while (/= start end)
       (setq next (next-single-property-change start prop object end)
@@ -444,7 +445,11 @@ also expects VALUE to be a single value, not a list."
         (setq prev (list prev)))
       (unless (memq value prev)
         (put-text-property start next prop
-                           (append prev (list value))
+                           ;; Reduce GC pressure by not making a list if it's
+                           ;; just a single face.
+                           (if prev
+                               (append prev (list value))
+                             value)
                            object))
       (setq start next))))
 


### PR DESCRIPTION
Currently, the text property `face` is always set to a list, even if there is only one face. This is technically correct, but inefficient, since it creates unnecessary cons cells, which increase GC pressure.

Additionally, it affects packages that incorrectly assumes `face` to be a singleton (like `flyspell`; see #168).

With this change, `face` is not set to a list until there is more than one face.