### PR TITLE
Make tree-sitter-node-at-pos accept special node-type arguments :named and :anonymous

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## [Unreleased]
 - Reduced GC pressure by not making the text property `face` a list if there is only one face.
 - Recast `tree-sitter-node-at-point` as more general `tree-sitter-node-at-pos`, taking optional POS argument.
+- Made `tree-sitter-node-at-pos` accept special node-type arguments `:named` and `:anonymous`.
 
 ## [0.15.1] - 2021-03-20
 - Fixed some invalid query patterns [causing SIGABRT](https://github.com/emacs-tree-sitter/elisp-tree-sitter/issues/125), by upgrading `tree-sitter` crate.

--- a/lisp/tree-sitter-tests.el
+++ b/lisp/tree-sitter-tests.el
@@ -228,7 +228,7 @@ If RESET is non-nil, also do another full parse and check again."
       (delete-region beg end)
       (tsc-test-tree-sexp orig-sexp :reset))))
 
-(ert-deftest minor-mode::node-at-point ()
+(ert-deftest minor-mode::node-at-pos ()
   (tsc-test-lang-with-file 'rust "lisp/test-files/types.rs"
     (should (eq 'source_file (tsc-node-type (tree-sitter-node-at-pos 'source_file))))
     (should (eq 'identifier (tsc-node-type (tree-sitter-node-at-pos nil 370))))

--- a/lisp/tree-sitter-tests.el
+++ b/lisp/tree-sitter-tests.el
@@ -230,7 +230,10 @@ If RESET is non-nil, also do another full parse and check again."
 
 (ert-deftest minor-mode::node-at-pos ()
   (tsc-test-lang-with-file 'rust "lisp/test-files/types.rs"
+    (should (eq 'use_declaration (tsc-node-type (tree-sitter-node-at-pos :named))))
     (should (eq 'source_file (tsc-node-type (tree-sitter-node-at-pos 'source_file))))
+    (should (equal "use" (tsc-node-type (tree-sitter-node-at-pos :anonymous))))
+    (should (null (tree-sitter-node-at-pos :anonymous (line-end-position))))
     (should (eq 'identifier (tsc-node-type (tree-sitter-node-at-pos nil 370))))
     (search-forward "erase_")
     (should (eq 'identifier (tsc-node-type (tree-sitter-node-at-pos))))
@@ -241,6 +244,8 @@ If RESET is non-nil, also do another full parse and check again."
     (should (null (tree-sitter-node-at-pos 'non-existing-node-type)))
     (search-forward "struc")
     (should (equal "struct" (tsc-node-type (tree-sitter-node-at-pos))))
+    (should (equal "struct" (tsc-node-type (tree-sitter-node-at-pos :anonymous))))
+    (should (eq 'struct_item (tsc-node-type (tree-sitter-node-at-pos :named))))
     (should (eq 'struct_item (tsc-node-type (tree-sitter-node-at-pos 'struct_item))))))
 
 (ert-deftest node::eq ()


### PR DESCRIPTION
xref #169

This PR teaches `tree-sitter-node-at-pos` to accept special NODE-TYPE arguments of `:named` and `:anonymous`, which return the smallest named or smallest anonymous syntax nodes at POS, respectively.

The quoted nil `'nil` in `pcase` looks odd, but is correct.

This defensive coding might not be needed: `(when (and node (stringp (tsc-node-type node))) node)`.

I'm not sure if this is helpful and correct documentation, as written:

```
Whenever NODE-TYPE is non-nil, it is possible for the function to return nil.
```

Can the function return nil when NODE-TYPE is nil?  Edit: I mean, in a tree-sitter buffer?

I noticed `FIX: Signal an error for non-existing node types` in the test file.  What needs to be done there?