### PR TITLE
Strict option to signal error for non-existing node types in tree-sitter-node-at-pos

### DIFF
--- a/lisp/tree-sitter-tests.el
+++ b/lisp/tree-sitter-tests.el
@@ -238,10 +238,10 @@ If RESET is non-nil, also do another full parse and check again."
     (search-forward "erase_")
     (should (eq 'identifier (tsc-node-type (tree-sitter-node-at-pos))))
     (should (eq 'function_item (tsc-node-type (tree-sitter-node-at-pos 'function_item))))
-    (should (null (tree-sitter-node-at-pos "function_item")))
+    (should-error (tree-sitter-node-at-pos "function_item"))
     (should (null (tree-sitter-node-at-pos 'impl_item)))
-    ;; FIX: Signal an error for non-existing node types.
-    (should (null (tree-sitter-node-at-pos 'non-existing-node-type)))
+    (should (null (tree-sitter-node-at-pos 'non-existing-node-type nil 'ignore-invalid-type)))
+    (should-error (tree-sitter-node-at-pos 'non-existing-node-type nil))
     (search-forward "struc")
     (should (equal "struct" (tsc-node-type (tree-sitter-node-at-pos))))
     (should (equal "struct" (tsc-node-type (tree-sitter-node-at-pos :anonymous))))


### PR DESCRIPTION
https://github.com/emacs-tree-sitter/elisp-tree-sitter/pull/171#issuecomment-912477047

> `tree-sitter-node-at-pos` should be made to signal an error when `NODE-TYPE` is not in the grammar. I'm still not sure whether there should be a corresponding parameter to toggle that. It could be a separate PR, though.

This may not be the best implementation.  Is this really the easiest way to access the list of named node types?

Also, per your comment, you haven't decided whether `STRICT` should be optional.

In my own contributions to [pygn-mode](https://github.com/dwcoates/pygn-mode/blob/bbc532a85b7a5555cbf1f0b4cd91214cf9fa6751/pygn-mode.el#L835), I am leaning on the non-strict expectation for forward compatibility with node-types which are not yet released in tree-sitter-langs.  But that is just one data point, and not a big deal to change.