### PR TITLE
emacs-tree-sitter.org: use (require 'tree-sitter-langs)

### DIFF
--- a/doc/emacs-tree-sitter.org
+++ b/doc/emacs-tree-sitter.org
@@ -93,8 +93,11 @@ The minor mode ~tree-sitter-mode~ provides a buffer-local syntax tree, which is 
 It can be toggled in a buffer by the command ~tree-sitter-mode~, or enabled through major mode hooks:
 
 #+begin_src emacs-lisp
+  (require 'tree-sitter-langs)
   (add-hook 'rust-mode-hook #'tree-sitter-mode)
 #+end_src
+
+The ~(require 'tree-sitter-langs)~ is needed for a number of variables to get initialized, such as ~tree-sitter-major-mode-language-alist~.
 
 To enable it for all supported major modes:
 


### PR DESCRIPTION
The documentation as it is confusing: it basically says you have to
enable tree-sitter-mode, and stuff will just work. Well it actually
doesn't, because the variable `tree-sitter-major-mode-language-alist`
won't get set until you execute (require 'tree-sitter-langs).

And it is not clear at all that this line needs to be executed because
all you get is `No language registered for major mode` message. Usually
lack of (require) results in missing function definitions, so in this
case there's no reason a user seeing the error would think "aha, I need
a (require) call".

So let's avoid confusion by mentioning the (require) line explicitly.