### PR TITLE
Describe type of tree-sitter-hl-default-patterns

### DIFF
--- a/lisp/tree-sitter-hl.el
+++ b/lisp/tree-sitter-hl.el
@@ -275,7 +275,9 @@ the following code disables keyword highlighting:
 (defvar-local tree-sitter-hl-default-patterns nil
   "Default syntax highlighting patterns.
 This should be set by major modes that want to integrate with `tree-sitter-hl'.
-It plays a similar role to `font-lock-defaults'.")
+It plays a similar role to `font-lock-defaults'.
+It is a string used to query tree sitter.  The format is described at
+https://tree-sitter.github.io/tree-sitter/syntax-highlighting#highlights.")
 
 (defvar tree-sitter-hl--patterns-alist nil
   "Additional language-specific syntax highlighting patterns.


### PR DESCRIPTION
I had a hard time figuring out how to set `tree-sitter-hl-default-patterns`, and I think something like this would have helped a lot.