### PR TITLE
Improve tree traversal APIs

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -89,3 +89,5 @@ jobs:
         run: npm install -g tree-sitter-cli@0.19.3
       - run: bin/test
         if: ${{ !matrix.target }}
+      - run: bin/test bench
+        if: ${{ !matrix.target }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -78,6 +78,8 @@ jobs:
         run: npm install -g tree-sitter-cli@0.19.3
       - run: bin/test
         if: ${{ !matrix.target }}
+      - run: bin/test bench
+        if: ${{ !matrix.target }}
 
       - name: Rename cross-build's binary
         if: matrix.target

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
+- Added APIs to traverse the syntax tree: `tsc-traverse-do`, `tsc-traverse-mapc`, `tsc-traverse-iter`. The traversal is depth-first pre-order.
+- Improved syntax tree rendering's performance in `tree-sitter-debug`.
+- Added optional params `props` and `output` to `tsc-current-node`, which allows retrieving node properties, instead of the node object itself. This enables performance optimizations in uses cases that deal with a large number of nodes.
 
 ## 0.17.0 - 2022-01-29
 - Added customization option `tsc-dyn-get-from`, which is a list of sources to get the dynamic module `tsc-dyn` from. Its default value is `(:github :compilation)`.

--- a/bin/test
+++ b/bin/test
@@ -14,6 +14,8 @@ if [[ $* == "watch" ]]; then
 else
     if [[ $* == "integ" ]]; then
         test_mod="tsc-dyn-get-tests.el"
+    elif [[ $* == "bench" ]]; then
+        test_mod="tree-sitter-bench.el"
     else
         test_mod="tree-sitter-tests.el"
     fi

--- a/bin/test.ps1
+++ b/bin/test.ps1
@@ -11,6 +11,8 @@ if ($args[0] -eq "watch") {
 } else {
     if ($args[0] -eq "integ") {
         $test_mod = "tsc-dyn-get-tests.el"
+    } elseif ($args[0] -eq "bench") {
+        $test_mod = "tree-sitter-bench.el"
     } else {
         $test_mod = "tree-sitter-tests.el"
     }

--- a/core/src/cursor.rs
+++ b/core/src/cursor.rs
@@ -340,9 +340,12 @@ fn _iter_next_node(iterator: &mut DepthFirstIterator, props: Vector, output: Vec
 
 /// Return CURSOR's current node, if PROPS is nil.
 ///
-/// If PROPS is a vector of keywords, this function returns a vector containing the
-/// corresponding node properties instead of the node itself. If OUTPUT is also a
-/// vector, this function overwrites its contents instead of creating a new vector.
+/// If PROPS is a vector of property names, this function returns a vector
+/// containing the node's corresponding properties instead of the node itself. If
+/// OUTPUT is also a vector, this function overwrites its contents instead of
+/// creating a new vector.
+///
+/// See `tsc-valid-node-props' for the list of available properties.
 #[defun]
 fn _current_node<'e>(cursor: &RCursor, props: Option<Vector<'e>>, output: Option<Vector<'e>>, env: &'e Env) -> Result<Value<'e>> {
     macro_rules! sugar {

--- a/core/src/cursor.rs
+++ b/core/src/cursor.rs
@@ -1,15 +1,17 @@
 use std::{
+    os,
     cell::{Ref, RefCell},
     mem,
     ops::{Deref, DerefMut},
 };
 
-use emacs::{defun, Result, Value, GlobalRef};
+use emacs::{defun, Result, Value, GlobalRef, Vector};
 use tree_sitter::{Tree, TreeCursor};
 
 use crate::{
     types::{self, Shared, Either, BytePos},
-    node::RNode,
+    tree::Borrowed,
+    node::{RNode, LispUtils},
     lang::Language,
 };
 
@@ -17,6 +19,7 @@ use crate::{
 
 /// Wrapper around `tree_sitter::TreeCursor` that can have 'static lifetime, by keeping a
 /// ref-counted reference to the underlying tree.
+#[derive(Clone)]
 pub struct RCursor {
     tree: Shared<Tree>,
     inner: TreeCursor<'static>,
@@ -116,6 +119,281 @@ fn make_cursor<'e>(
 #[defun]
 fn current_node(cursor: &RCursor) -> Result<RNode> {
     Ok(RNode::new(cursor.clone_tree(), |_| cursor.borrow().node()))
+}
+
+emacs::use_symbols! {
+    nil
+    wtf
+    iter_end_of_sequence
+
+    _next        => ":next"
+    _close       => ":close"
+
+    _field       => ":field"
+    _type        => ":type"
+    _named_p     => ":named-p"
+    _extra_p     => ":extra-p"
+    _error_p     => ":error-p"
+    _missing_p   => ":missing-p"
+    _has_error_p => ":has-error-p"
+    _start_byte  => ":start-byte"
+    _start_point => ":start-point"
+    _end_byte    => ":end-byte"
+    _end_point   => ":end-point"
+    _range       => ":range"
+    _byte_range  => ":byte-range"
+}
+
+use emacs::*;
+use emacs::func::{HandleCall, Manage};
+
+fn iterate(env: &CallEnv) -> Result<Value> {
+    let iter: &mut DepthFirstIterator = unsafe { mem::transmute(env.data) };
+    let control = env.get_arg(0);
+    iter_next(iter, control, nil.bind(env))
+}
+
+enum TraversalState {
+    Start,
+    Down,
+    Right,
+    Done,
+}
+
+struct DepthFirstIterator {
+    cursor: RCursor,
+    state: TraversalState,
+    depth: usize,
+}
+
+impl DepthFirstIterator {
+    fn new(tree: Borrowed<Tree>) -> Self {
+        Self {
+            cursor: RCursor::new(tree.clone(), |tree| tree.walk()),
+            state: Start,
+            depth: 0,
+        }
+    }
+
+    #[inline]
+    fn item(&self) -> Option<(RNode, usize)> {
+        Some((
+            RNode::new(self.cursor.clone_tree(),
+                       |_| self.cursor.borrow().node()),
+            self.depth,
+        ))
+    }
+
+    fn close(&mut self) {
+        self.state = Done;
+    }
+}
+
+use TraversalState::*;
+
+impl Iterator for DepthFirstIterator {
+    type Item = (RNode, usize);
+
+    fn next(&mut self) -> Option<Self::Item> {
+        match self.state {
+            Start => {
+                self.state = Down;
+                self.item()
+            }
+            Down => {
+                if self.cursor.borrow_mut().goto_first_child() {
+                    self.depth += 1;
+                    self.item()
+                } else {
+                    self.state = Right;
+                    self.next()
+                }
+            }
+            Right => {
+                if self.cursor.borrow_mut().goto_next_sibling() {
+                    self.state = Down;
+                    self.item()
+                } else if self.cursor.borrow_mut().goto_parent() {
+                    self.depth -= 1;
+                    self.next()
+                } else {
+                    self.state = Done;
+                    self.next()
+                }
+            }
+            Done => None
+        }
+    }
+}
+
+unsafe extern "C" fn iterate_wrapper(
+    env: *mut raw::emacs_env,
+    nargs: isize,
+    args: *mut raw::emacs_value,
+    data: *mut os::raw::c_void,
+) -> raw::emacs_value {
+    let env = Env::new(env);
+    let env = CallEnv::new(env, nargs, args, data);
+    env.handle_call(iterate)
+}
+
+#[defun]
+fn generate_depth_first<'e>(tree: Borrowed<'e, Tree>, env: &'e Env) -> Result<Value<'e>> {
+    // let tree = tree.borrow();
+    let iterator = DepthFirstIterator::new(tree);
+    let iterator = Box::new(iterator);
+    let iterator = Box::leak(iterator);
+    unsafe {
+        let iterator = mem::transmute(iterator);
+        env.make_function(iterate_wrapper, 1..2, "", iterator)
+    }
+}
+
+#[defun]
+fn iter_next<'e>(iter: &mut DepthFirstIterator, control: Value<'e>, _yield_result: Value) -> Result<Value<'e>> {
+    let env = control.env;
+    if control.eq(_next.bind(&env)) {
+        match iter.next() {
+            Some((node, depth)) =>
+                env.cons(node, depth),
+            None =>
+                env.signal(iter_end_of_sequence, []),
+        }
+    } else if control.eq(_close.bind(&env)) {
+        iter.close();
+        ().into_lisp(env)
+    } else {
+        env.signal(wtf, [])
+    }
+}
+
+#[defun(user_ptr)]
+fn _iter(tree: Borrowed<Tree>) -> Result<DepthFirstIterator> {
+    Ok(DepthFirstIterator::new(tree))
+}
+
+#[defun]
+fn _iter_next(iter: &mut DepthFirstIterator) -> Result<bool> {
+    Ok(iter.next().is_some())
+}
+
+#[defun]
+fn _iter_close(iter: &mut DepthFirstIterator) -> Result<()> {
+    Ok(iter.close())
+}
+
+#[defun]
+fn _iter_current_node(iter: &mut DepthFirstIterator, props: Option<Vector>, combined_output: Vector) -> Result<()> {
+    let env = combined_output.value().env;
+    let cursor = &iter.cursor;
+    let output = combined_output.get(0)?;
+    let node = _current_node(cursor, props, output, env)?;
+    if props.is_none() {
+        combined_output.set(0, node)?;
+    }
+    combined_output.set(1, iter.depth)?;
+    // Ok(data)
+    // Ok(combined_output)
+    Ok(())
+}
+
+#[defun]
+fn _current_node<'e>(cursor: &RCursor, props: Option<Vector<'e>>, output: Option<Vector<'e>>, env: &'e Env) -> Result<Value<'e>> {
+    macro_rules! sugar {
+        ($prop:ident, $env:ident) => {
+            macro_rules! eq {
+                ($name:ident) => ($prop.eq($name.bind($env)))
+            }
+        }
+    }
+    let node = cursor.borrow().node();
+    match props {
+        None => RNode::new(cursor.clone_tree(), |_| node).into_lisp(env),
+        Some(props) => {
+            let result = match output {
+                None => env.make_vector(props.len(), ())?,
+                Some(output) => output,
+            };
+            for (i, prop) in props.into_iter().enumerate() {
+                sugar!(prop, env);
+                if eq!(_type) {
+                    result.set(i, node.lisp_type())?;
+                } else if eq!(_byte_range) {
+                    result.set(i, node.lisp_byte_range(env)?)?;
+                } else if eq!(_start_byte) {
+                    result.set(i, node.lisp_start_byte())?;
+                } else if eq!(_end_byte) {
+                    result.set(i, node.lisp_end_byte())?;
+                } else if eq!(_field) {
+                    result.set(i, current_field(cursor)?)?;
+                } else if eq!(_named_p) {
+                    result.set(i, node.is_named())?;
+                } else if eq!(_extra_p) {
+                    result.set(i, node.is_extra())?;
+                } else if eq!(_error_p) {
+                    result.set(i, node.is_error())?;
+                } else if eq!(_missing_p) {
+                    result.set(i, node.is_missing())?;
+                } else if eq!(_has_error_p) {
+                    result.set(i, node.has_error())?;
+                } else if eq!(_start_point) {
+                    result.set(i, node.lisp_start_point())?;
+                } else if eq!(_end_point) {
+                    result.set(i, node.lisp_end_point())?;
+                } else if eq!(_range) {
+                    result.set(i, node.lisp_range())?;
+                } else {
+                    result.set(i, RNode::new(cursor.clone_tree(), |_| node))?;
+                }
+            }
+            result.into_lisp(env)
+        }
+    }
+}
+
+#[defun]
+fn _traverse_depth_first_native(tree: Borrowed<Tree>, func: Value, props: Option<Vector>) -> Result<()> {
+    let mut iterator = DepthFirstIterator::new(tree);
+    let env = func.env;
+    let output = match props {
+        None => None,
+        Some(props) => Some(env.make_vector(props.len(), ())?),
+    };
+    // Can't use a for loop because we need to access the cursor to process each item.
+    let mut item: Option<(RNode, usize)> = iterator.next();
+    while item.is_some() {
+        let result = _current_node(&iterator.cursor, props, output, env)?;
+        let (_, depth) = item.unwrap();
+        // Safety: the returned value is unused.
+
+        unsafe { func.call_unprotected((result, depth))?; }
+
+        // // 0
+        // unsafe { func.call_unprotected([])?; }
+
+        // // 27
+        // unsafe { func.call_unprotected((result, depth, func, props))?; }
+
+        // // 13
+        // unsafe { func.call_unprotected((result, depth))?; }
+
+        // // 10
+        // env.vector((result, depth))?;
+
+        // // 6
+        // env.cons(result, depth)?;
+
+        // // 0
+        // use emacs::call::IntoLispArgs;
+        // (result, depth).into_lisp_args(env)?;
+
+        item = iterator.next();
+    }
+    // for (_, depth) in iterator {
+    //     let result = _current_node(&iterator.cursor.clone(), props, output, env)?;
+    //     func.call((result, depth))?;
+    // }
+    Ok(())
 }
 
 /// Return the field id of CURSOR's current node.

--- a/core/src/cursor.rs
+++ b/core/src/cursor.rs
@@ -298,6 +298,16 @@ fn _iter_current_node(iter: &mut DepthFirstIterator, props: Option<Vector>, comb
 }
 
 #[defun]
+fn _iter_next_node(iter: &mut DepthFirstIterator, props: Option<Vector>, combined_output: Vector) -> Result<bool> {
+    if iter.next().is_some() {
+        _iter_current_node(iter, props, combined_output)?;
+        Ok(true)
+    } else {
+        Ok(false)
+    }
+}
+
+#[defun]
 fn _current_node<'e>(cursor: &RCursor, props: Option<Vector<'e>>, output: Option<Vector<'e>>, env: &'e Env) -> Result<Value<'e>> {
     macro_rules! sugar {
         ($prop:ident, $env:ident) => {

--- a/core/src/cursor.rs
+++ b/core/src/cursor.rs
@@ -325,7 +325,7 @@ fn _current_node<'e>(cursor: &RCursor, props: Option<Vector<'e>>, output: Option
 }
 
 #[defun]
-fn _traverse_depth_first_native(tree_or_node: TreeOrNode, func: Value, props: Option<Vector>) -> Result<()> {
+fn _traverse_mapc(func: Value, tree_or_node: TreeOrNode, props: Option<Vector>) -> Result<()> {
     let mut iterator = DepthFirstIterator::new(tree_or_node);
     let env = func.env;
     let output = match props {

--- a/core/src/cursor.rs
+++ b/core/src/cursor.rs
@@ -153,12 +153,6 @@ fn make_cursor(tree_or_node: TreeOrNode) -> Result<RCursor> {
     Ok(tree_or_node.walk())
 }
 
-/// Return CURSOR's current node.
-#[defun]
-fn current_node(cursor: &RCursor) -> Result<RNode> {
-    Ok(RNode::new(cursor.clone_tree(), |_| cursor.borrow().node()))
-}
-
 /// Return the field id of CURSOR's current node.
 /// Return nil if the current node doesn't have a field.
 #[defun]
@@ -414,6 +408,7 @@ fn get<'e>(prop: Value<'e>, node: Node, cursor: &RCursor) -> Result<Value<'e>> {
     } else if eq!(_range) {
         node.lisp_range().into_lisp(env)
     } else {
+        // FIX: Signal an error instead.
         ().into_lisp(env)
     }
 }

--- a/core/src/tree.rs
+++ b/core/src/tree.rs
@@ -10,7 +10,7 @@ use crate::{
 
 // XXX: If we pass a &, #[defun] will assume it's refcell-wrapped. If we pass a Value, we need
 // .into_rust() boilerplate. This is a trick to avoid both.
-type Borrowed<'e, T> = &'e Shared<T>;
+pub(crate) type Borrowed<'e, T> = &'e Shared<T>;
 
 impl_pred!(tree_p, &Shared<Tree>);
 

--- a/core/src/types.rs
+++ b/core/src/types.rs
@@ -1,7 +1,6 @@
 use std::{
     mem,
     cell::RefCell,
-    marker::PhantomData,
     rc::Rc,
 };
 
@@ -145,22 +144,5 @@ impl FromLisp<'_> for Range {
         let start_point = vector.get::<Point>(2)?.into();
         let end_point = vector.get::<Point>(3)?.into();
         Ok(tree_sitter::Range { start_byte, end_byte, start_point, end_point }.into())
-    }
-}
-
-// -------------------------------------------------------------------------------------------------
-
-pub enum Either<'e, L, R> where L: FromLisp<'e>, R: FromLisp<'e> {
-    Left(L, PhantomData<&'e ()>),
-    Right(R, PhantomData<&'e ()>),
-}
-
-impl<'e, L, R> FromLisp<'e> for Either<'e, L, R> where L: FromLisp<'e>, R: FromLisp<'e> {
-    fn from_lisp(value: Value<'e>) -> Result<Self> {
-        if let Ok(value) = value.into_rust::<L>() {
-            return Ok(Either::Left(value, PhantomData));
-        }
-        let value = value.into_rust::<R>()?;
-        Ok(Either::Right(value, PhantomData))
     }
 }

--- a/core/tsc.el
+++ b/core/tsc.el
@@ -176,6 +176,25 @@ This function must be called in NODE's source buffer."
 Return the index of the child node if one was found, nil otherwise."
   (tsc-goto-first-child-for-byte cursor (position-bytes position)))
 
+(defun tsc-current-node (cursor &optional props output)
+  "Return CURSOR's current node.
+
+If the optional arg PROPS is a vector of property names, this function returns a
+vector containing the node's corresponding properties. If the optional arg
+OUTPUT is also non-nil, it must be a vector of the same length, where the
+properties will be written into.
+
+PROPS can also be a single property name, in which case this function returns
+only that property, and OUTPUT is ignored.
+
+See `tsc-valid-node-props' for the list of available properties."
+  (tsc--check-node-props props)
+  ;; TODO: Fix this.
+  (when (or (eq props :depth)
+            (and (seqp props) (cl-find :depth props)))
+    (error "Cursor doesn't currently support :depth property"))
+  (tsc--current-node cursor props output))
+
 (defun tsc-lang-field-id (language field)
   "Return the numeric id of FIELD in LANGUAGE. FIELD should be a keyword."
   (unless (keywordp field)
@@ -292,7 +311,7 @@ e.g. automatically through escape analysis. How about porting ELisp to GraalVM?"
                                props)))
       (error "Invalid node properties %s" invalid-props)))
    ((null props) nil)
-   (t (error "Expected vectors or keyword %s" props))))
+   (t (error "Expected vectors, keyword, or nil %s" props))))
 
 (defun tsc-traverse-mapc (func tree-or-node &optional props)
   "Call FUNC for each node of TREE-OR-NODE.

--- a/core/tsc.el
+++ b/core/tsc.el
@@ -291,6 +291,7 @@ e.g. automatically through escape analysis. How about porting ELisp to GraalVM?"
                                  (not (memq kw tsc-valid-node-props)))
                                props)))
       (error "Invalid node properties %s" invalid-props)))
+   ((null props) nil)
    (t (error "Expected vectors or keyword %s" props))))
 
 (defun tsc-traverse-mapc (func tree-or-node &optional props)

--- a/core/tsc.el
+++ b/core/tsc.el
@@ -258,11 +258,7 @@ QUERY. Otherwise, a newly created query-cursor is used."
    (or cursor (tsc-make-query-cursor)) query node text-function))
 
 
-;;; Utilities.
-
-(defun tsc-pp-to-string (tree)
-  "Return the pretty-printed string of TREE's sexp."
-  (pp-to-string (read (tsc-tree-to-sexp tree))))
+;;; Traversal.
 
 (defconst tsc-valid-node-props '(field
                                  type
@@ -374,6 +370,13 @@ VARS must be a vector of symbols. For example, to crudely render a syntax tree:
                            collect `(,(aref vars i)
                                      (aref ,output ,i))))
            ,@body)))))
+
+
+;;; Utilities.
+
+(defun tsc-pp-to-string (tree)
+  "Return the pretty-printed string of TREE's sexp."
+  (pp-to-string (read (tsc-tree-to-sexp tree))))
 
 (defun tsc--node-steps (node)
   "Return the sequence of steps from the root node to NODE.

--- a/doc/emacs-tree-sitter.org
+++ b/doc/emacs-tree-sitter.org
@@ -628,7 +628,17 @@ Tree-walking functions enable efficient traversal of the syntax tree.
 *** Traversing All Descendant Nodes
 These functions are high-level APIs that allow traversing the syntax tree in depth-first pre-order.
 
-When dealing with a large number of nodes, working with node objects creates a huge pressure on the garbage collector. For better performance, it's advisable to extract and work with individual node properties.
+When dealing with a large number of nodes, working with node objects creates a huge pressure on the garbage collector. For better performance, it's advisable to extract and work with individual node properties. The constant ~tsc-valid-node-props~ holds the list of all available property names.
+# TODO: Make :exports results work with ox-hugo.
+#+begin_src emacs-lisp
+  '(:type
+    :field ;node's field name within the parent node
+    :depth ;node's depth, relative to the iterator's start
+    :named-p :extra-p :error-p :missing-p :has-error-p
+    :start-byte :end-byte
+    :start-point :end-point
+    :range :byte-range)
+#+end_src
 
 - ~tsc-traverse-do~ /~(vars tree-or-node) body~/ :: Evaluate ~body~ with ~vars~ bound to corresponding properties of each traversed node.
     #+begin_src emacs-lisp
@@ -637,7 +647,7 @@ When dealing with a large number of nodes, working with node objects creates a h
           (insert (make-string depth \? )     ;indentation
                   (format "%S" type) "\n")))
     #+end_src
-- ~tsc-traverse-mapc~ /~func tree-or-node [props]~/ :: Call ~func~ for each traversed node, passing the node as the argument. If the vector of keywords ~props~ is specified, ~func~ receives a vector containing the node's properties instead. *Do not keep a reference to the vector*, as it is reused across invocations. Use ~pcase-let~ to extract the properties.
+- ~tsc-traverse-mapc~ /~func tree-or-node [props]~/ :: Call ~func~ for each traversed node, passing the node as the argument. If ~props~ is a vector of property names, ~func~ receives a vector containing the node's properties instead. *Do not keep a reference to the vector*, as it is reused across invocations. Use ~pcase-let~ to extract the properties.
     #+begin_src emacs-lisp
       (tsc-traverse-mapc
        (lambda (props)
@@ -648,7 +658,7 @@ When dealing with a large number of nodes, working with node objects creates a h
        tree
        [:type :depth :named-p])
     #+end_src
-- ~tsc-traverse-iter~ /~tree-or-node [props]~/ :: Create an iterator that yields traversed nodes. If the vector of keywords ~props~ is specified, the iterator yields a vector containing the node's properties instead. *Do not keep a reference to the vector*, as it is reused across iterations. Use ~pcase-let~ to extract the properties.
+- ~tsc-traverse-iter~ /~tree-or-node [props]~/ :: Create an iterator that yields traversed nodes. If ~props~ is a vector of property names, the iterator yields a vector containing the node's properties instead. *Do not keep a reference to the vector*, as it is reused across iterations. Use ~pcase-let~ to extract the properties.
     #+begin_src emacs-lisp
       (iter-do (props (tsc-traverse-iter
                        tree [:type :depth :named-p]))

--- a/doc/emacs-tree-sitter.org
+++ b/doc/emacs-tree-sitter.org
@@ -623,9 +623,44 @@ As described in the previous section, the ~-named-~  variants of the functions i
 :PROPERTIES:
 :EXPORT_FILE_NAME: walking
 :END:
-Tree-walking functions enable efficient traversal of the syntax tree with the help of a stateful ~cursor~ object.
+Tree-walking functions enable efficient traversal of the syntax tree.
 
-- ~tsc-make-cursor~ /~node-or-tree~/ :: Create a new cursor on a node. The cursor /cannot move out/ of this node. If called on a tree, the cursor is created on the tree's root node.
+*** Traversing All Descendant Nodes
+These functions are high-level APIs that allow traversing the syntax tree in depth-first pre-order.
+
+When dealing with a large number of nodes, working with node objects creates a huge pressure on the garbage collector. For better performance, it's advisable to extract and work with individual node properties.
+
+- ~tsc-do-tree~ /~(vars tree-or-node) body~/ :: Evaluate ~body~ with ~vars~ bound to corresponding properties of each traversed node.
+    #+begin_src emacs-lisp
+      (tsc-do-tree ([type depth named-p] tree)
+        (when named-p                         ;AST
+          (insert (make-string depth \? )     ;indentation
+                  (format "%S" type) "\n")))
+    #+end_src
+- ~tsc-traverse-depth-first-native~ /~tree-or-node fn [props]~/ :: Call ~fn~ for each traversed node, passing the node as the argument. If the vector of keywords ~props~ is specified, ~fn~ receives a vector containing the node's properties instead. *Do not keep a reference to the vector*, as it is reused across invocations. Use ~pcase-let~ to extract the properties.
+    #+begin_src emacs-lisp
+      (tsc-traverse-depth-first-native
+       tree (lambda (props)
+              (pcase-let ((`[,type ,depth ,named-p] props))
+                (when named-p                     ;AST
+                  (insert (make-string depth \? ) ;indentation
+                          (format "%S" type) "\n"))))
+       [:type :depth :named-p])
+    #+end_src
+- ~tsc-traverse-depth-first-iterator~ /~tree-or-node [props]~/ :: Create an iterator that yields traversed nodes. If the vector of keywords ~props~ is specified, the iterator yields a vector containing the node's properties instead. *Do not keep a reference to the vector*, as it is reused across iterations. Use ~pcase-let~ to extract the properties.
+    #+begin_src emacs-lisp
+      (iter-do (props (tsc-traverse-depth-first-iterator
+                       tree [:type :depth :named-p]))
+        (pcase-let ((`[,type ,depth ,named-p] props))
+          (when named-p                       ;AST
+            (insert (make-string depth \? )   ;indentation
+                    (format "%S" type) "\n"))))
+    #+end_src
+
+*** Walking Step-by-step
+These functions are the low-level APIs that allow walking through the syntax tree one node at a time, with the help of a stateful ~cursor~ object.
+
+- ~tsc-make-cursor~ /~tree-or-node~/ :: Create a new cursor on a node. The cursor /cannot move out/ of this node. If called on a tree, the cursor is created on the tree's root node.
 - ~tsc-goto-parent~ /~cursor~/ :: <br>
 - ~tsc-goto-first-child~ /~cursor~/ :: <br>
 - ~tsc-goto-next-sibling~ /~cursor~/ :: Attempt to move the cursor to the parent node, the first child node, or the next sibling node. This function returns t if the move was successful, nil if the move is invalid.

--- a/doc/emacs-tree-sitter.org
+++ b/doc/emacs-tree-sitter.org
@@ -647,7 +647,7 @@ When dealing with a large number of nodes, working with node objects creates a h
           (insert (make-string depth \? )     ;indentation
                   (format "%S" type) "\n")))
     #+end_src
-- ~tsc-traverse-mapc~ /~func tree-or-node [props]~/ :: Call ~func~ for each traversed node, passing the node as the argument. If ~props~ is a vector of property names, ~func~ receives a vector containing the node's properties instead. *Do not keep a reference to the vector*, as it is reused across invocations. Use ~pcase-let~ to extract the properties.
+- ~tsc-traverse-mapc~ /~func tree-or-node [props]~/ :: Call ~func~ for each traversed node, passing the node as the argument. If ~props~ is a vector of property names, ~func~ receives a vector containing the node's properties instead. *Do not keep a reference to the vector*, as it is reused across invocations. Use ~pcase-let~ to extract the properties instead.
     #+begin_src emacs-lisp
       (tsc-traverse-mapc
        (lambda (props)
@@ -658,7 +658,7 @@ When dealing with a large number of nodes, working with node objects creates a h
        tree
        [:type :depth :named-p])
     #+end_src
-- ~tsc-traverse-iter~ /~tree-or-node [props]~/ :: Create an iterator that yields traversed nodes. If ~props~ is a vector of property names, the iterator yields a vector containing the node's properties instead. *Do not keep a reference to the vector*, as it is reused across iterations. Use ~pcase-let~ to extract the properties.
+- ~tsc-traverse-iter~ /~tree-or-node [props]~/ :: Create an iterator that yields traversed nodes. If ~props~ is a vector of property names, the iterator yields a vector containing the node's properties instead. *Do not keep a reference to the vector*, as it is reused across iterations. Use ~pcase-let~ to extract the properties instead.
     #+begin_src emacs-lisp
       (iter-do (props (tsc-traverse-iter
                        tree [:type :depth :named-p]))

--- a/doc/emacs-tree-sitter.org
+++ b/doc/emacs-tree-sitter.org
@@ -167,6 +167,7 @@ The variable ~tree-sitter-load-path~ is a list of directories that the function 
   (tree-sitter-require 'rust)
 #+end_src
 
+*** tree-sitter-langs
 The package ~tree-sitter-langs~ is a language bundle that contains shared libraries for some languages (as well as syntax highlighting queries). When it is loaded, its shared libraries are prioritized over the CLI's directory.
 
 Syntax-aware language-agnostic mechanisms are meant to be defined by ~tree-sitter-mode~ and its dependent minor modes. They determine the language object to use by consulting the variable ~tree-sitter-major-mode-language-alist~. This list is empty by default, and gets populated by ~tree-sitter-langs~ when it is loaded, and by language major modes that are ~tree-sitter~-aware.
@@ -191,7 +192,7 @@ If, for some reason, you cannot update, the older binaries can be downloaded fro
 :EXPORT_TITLE: Syntax Highlighting
 :END:
 
-Syntax highlighting is provided by the minor mode ~tree-sitter-hl-mode~. It overrides the regex-based highlighting provided by ~font-lock-mode~, using the syntax tree provided by ~tree-sitter-mode~. It is based on [[* Queries][*tree queries*]], a system for pattern-matching on Tree-sitter's syntax trees.
+The minor mode ~tree-sitter-hl-mode~ provides the framework for syntax highlighting. It overrides the regex-based highlighting provided by ~font-lock-mode~, using the syntax tree provided by ~tree-sitter-mode~. It is based on [[* Queries][*tree queries*]], a system for pattern-matching on Tree-sitter's syntax trees.
 
 It can be toggled in a buffer by the command ~tree-sitter-hl-mode~, or enabled through major mode hooks:
 #+begin_src emacs-lisp
@@ -203,6 +204,11 @@ To enable it whenever possible (assuming the language major modes were already i
   (global-tree-sitter-mode)
   (add-hook 'tree-sitter-after-on-hook #'tree-sitter-hl-mode)
 #+end_src
+
+{{% notice info %}}
+Like ~font-lock-mode~, ~tree-sitter-hl-mode~ provides only the mechanisms. The actual highlighting rules are provided by language-specific packages, or a language bundle like ~tree-sitter-langs~.
+{{% /notice %}}
+
 *** tree-sitter-langs
 The package ~tree-sitter-langs~ provides syntax highlighting [[https://github.com/emacs-tree-sitter/tree-sitter-langs/tree/master/queries][queries]] for some languages.
 

--- a/doc/emacs-tree-sitter.org
+++ b/doc/emacs-tree-sitter.org
@@ -562,7 +562,11 @@ For more details, see Tree-sitter's documentation:
 :EXPORT_FILE_NAME: inspecting
 :END:
 
-The result of parsing is a syntax tree of the entire source code (string, buffer). It contains syntax nodes that indicate the structure of the source code. Tree-sitter provides APIs to inspect and [[*Walking][traverse]] this structure, but does not support modifying it directly (for the purposes of source code transformation or generation).
+{{% notice info %}}
+If your code works with a large number of nodes, consider using the [[*Walking][traversal APIs]], which are more efficient.
+{{% /notice %}}
+
+The result of parsing is a syntax tree of the entire source code (string, buffer). It contains syntax nodes that indicate the structure of the source code. Tree-sitter provides APIs to inspect and traverse this structure, but does not support modifying it directly (for the purposes of source code transformation or generation).
 
 - ~tsc-root-node~ /~tree~/ :: Get the root node of a syntax tree.
 - ~tsc-changed-ranges~ /~old-tree new-tree~/ :: Compare an edited old syntax tree to a newly parsed one. It is typically used in ~tree-sitter-after-change-functions~ hook. This function returns a sequence of ranges whose syntactic structure has changed. Each range is a vector in the form of /~[start-bytepos end-bytepos start-point end-point]~/.
@@ -631,10 +635,7 @@ As described in the previous section, the ~-named-~  variants of the functions i
 :END:
 Tree-walking functions enable efficient traversal of the syntax tree.
 
-*** Traversing All Descendant Nodes
-These functions are high-level APIs that allow traversing the syntax tree in depth-first pre-order.
-
-When dealing with a large number of nodes, working with node objects creates a huge pressure on the garbage collector. For better performance, it's advisable to extract and work with individual node properties. The constant ~tsc-valid-node-props~ holds the list of all available property names.
+When dealing with a large number of nodes, working with node objects creates a huge pressure on the garbage collector. For better performance, it's advisable to extract and work with individual node properties. The constant ~tsc-valid-node-props~ holds the list of all available property names:
 # TODO: Make :exports results work with ox-hugo.
 #+begin_src emacs-lisp
   '(:type
@@ -645,6 +646,12 @@ When dealing with a large number of nodes, working with node objects creates a h
     :start-point :end-point
     :range :byte-range)
 #+end_src
+{{% notice note %}}
+Functions that accept a vector of property names can also accept a single property name, in which case only that property is returned/yielded, instead of a vector of properties.
+{{% /notice %}}
+
+*** Traversing All Descendant Nodes
+These functions are high-level APIs that allow traversing the syntax tree in depth-first pre-order.
 
 - ~tsc-traverse-do~ /~(vars tree-or-node) body~/ :: Evaluate ~body~ with ~vars~ bound to corresponding properties of each traversed node.
     #+begin_src emacs-lisp
@@ -683,8 +690,12 @@ These functions are the low-level APIs that allow walking through the syntax tre
 - ~tsc-goto-next-sibling~ /~cursor~/ :: Attempt to move the cursor to the parent node, the first child node, or the next sibling node. This function returns t if the move was successful, nil if the move is invalid.
 - ~tsc-goto-first-child-for-position~ /~cursor pos~/ :: Attempt to move the cursor to the first child node that extends beyond the given position. This function returns the index of the child node found, nil otherwise.
 - ~tsc-reset-cursor~ /~cursor node~/ :: Re-initialize the cursor to start on a different node.
-- ~tsc-current-node~ /~cursor~/ :: Get the node that the cursor is currently on.
-- ~tsc-current-field~ /~cursor~/ :: Get the field name (as a keyword) associated with the current node.
+- ~tsc-current-node~ /~cursor [props] [output]~/ :: Get the node that the cursor is currently on. If ~props~ is a vector of property names, return a vector containing the node's corresponding properties. If ~output~ is also non-nil, it must be a vector of the same length, where the properties will be written into.
+- ~tsc-current-field~ /~cursor~/ :: Get the field name (as a keyword) associated with the current node. This is equivalent to:
+    #+begin_src emacs-lisp
+      (tsc-current-node cursor :field)
+    #+end_src
+
 
 ** Querying
 :PROPERTIES:

--- a/doc/emacs-tree-sitter.org
+++ b/doc/emacs-tree-sitter.org
@@ -630,26 +630,27 @@ These functions are high-level APIs that allow traversing the syntax tree in dep
 
 When dealing with a large number of nodes, working with node objects creates a huge pressure on the garbage collector. For better performance, it's advisable to extract and work with individual node properties.
 
-- ~tsc-do-tree~ /~(vars tree-or-node) body~/ :: Evaluate ~body~ with ~vars~ bound to corresponding properties of each traversed node.
+- ~tsc-traverse-do~ /~(vars tree-or-node) body~/ :: Evaluate ~body~ with ~vars~ bound to corresponding properties of each traversed node.
     #+begin_src emacs-lisp
-      (tsc-do-tree ([type depth named-p] tree)
+      (tsc-traverse-do ([type depth named-p] tree)
         (when named-p                         ;AST
           (insert (make-string depth \? )     ;indentation
                   (format "%S" type) "\n")))
     #+end_src
-- ~tsc-traverse-depth-first-native~ /~tree-or-node fn [props]~/ :: Call ~fn~ for each traversed node, passing the node as the argument. If the vector of keywords ~props~ is specified, ~fn~ receives a vector containing the node's properties instead. *Do not keep a reference to the vector*, as it is reused across invocations. Use ~pcase-let~ to extract the properties.
+- ~tsc-traverse-mapc~ /~func tree-or-node [props]~/ :: Call ~func~ for each traversed node, passing the node as the argument. If the vector of keywords ~props~ is specified, ~func~ receives a vector containing the node's properties instead. *Do not keep a reference to the vector*, as it is reused across invocations. Use ~pcase-let~ to extract the properties.
     #+begin_src emacs-lisp
-      (tsc-traverse-depth-first-native
-       tree (lambda (props)
-              (pcase-let ((`[,type ,depth ,named-p] props))
-                (when named-p                     ;AST
-                  (insert (make-string depth \? ) ;indentation
-                          (format "%S" type) "\n"))))
+      (tsc-traverse-mapc
+       (lambda (props)
+         (pcase-let ((`[,type ,depth ,named-p] props))
+           (when named-p                          ;AST
+             (insert (make-string depth \? )      ;indentation
+                     (format "%S" type) "\n"))))
+       tree
        [:type :depth :named-p])
     #+end_src
-- ~tsc-traverse-depth-first-iterator~ /~tree-or-node [props]~/ :: Create an iterator that yields traversed nodes. If the vector of keywords ~props~ is specified, the iterator yields a vector containing the node's properties instead. *Do not keep a reference to the vector*, as it is reused across iterations. Use ~pcase-let~ to extract the properties.
+- ~tsc-traverse-iter~ /~tree-or-node [props]~/ :: Create an iterator that yields traversed nodes. If the vector of keywords ~props~ is specified, the iterator yields a vector containing the node's properties instead. *Do not keep a reference to the vector*, as it is reused across iterations. Use ~pcase-let~ to extract the properties.
     #+begin_src emacs-lisp
-      (iter-do (props (tsc-traverse-depth-first-iterator
+      (iter-do (props (tsc-traverse-iter
                        tree [:type :depth :named-p]))
         (pcase-let ((`[,type ,depth ,named-p] props))
           (when named-p                       ;AST

--- a/lisp/tree-sitter-debug.el
+++ b/lisp/tree-sitter-debug.el
@@ -15,6 +15,8 @@
 
 (require 'tree-sitter)
 
+(require 'generator)
+
 (defvar-local tree-sitter-debug--tree-buffer nil
   "Buffer used to display the syntax tree of this buffer.")
 

--- a/lisp/tree-sitter-debug.el
+++ b/lisp/tree-sitter-debug.el
@@ -80,15 +80,15 @@ This only takes effect if `tree-sitter-debug-jump-buttons' is non-nil."
         (erase-buffer)
         (pcase tree-sitter-debug-traversal-method
           (:native (tsc-traverse-depth-first-native
-                    tree (lambda (props depth)
-                           (pcase-let ((`[,named-p ,type ,start-byte ,end-byte] props))
+                    tree (lambda (props)
+                           (pcase-let ((`[,named-p ,type ,start-byte ,end-byte ,depth] props))
                              (tree-sitter-debug--display-node
                               named-p type start-byte end-byte depth)))
-                    [:named-p :type :start-byte :end-byte]))
+                    [:named-p :type :start-byte :end-byte :depth]))
           (:iterator (iter-do (item (tsc-traverse-depth-first-iterator
                                      tree
-                                     [:named-p :type :start-byte :end-byte]))
-                       (pcase-let ((`[[,named-p ,type ,start-byte ,end-byte] ,depth] item))
+                                     [:named-p :type :start-byte :end-byte :depth]))
+                       (pcase-let ((`[,named-p ,type ,start-byte ,end-byte ,depth] item))
                          (tree-sitter-debug--display-node
                           named-p type start-byte end-byte depth))))
           (:do-tree (tsc-do-tree ([named-p type start-byte end-byte depth] tree)

--- a/lisp/tree-sitter-debug.el
+++ b/lisp/tree-sitter-debug.el
@@ -91,7 +91,7 @@ This only takes effect if `tree-sitter-debug-jump-buttons' is non-nil."
 ;;         (insert node-text)))))
 
 (defvar tree-sitter-debug-traverse-function
-  #'tsc-traverse-depth-first-iterative)
+  #'tsc-traverse-depth-first-native)
 
 (defun tree-sitter-debug--display-tree (_old-tree)
   "Display the current `tree-sitter-tree'."

--- a/lisp/tree-sitter-debug.el
+++ b/lisp/tree-sitter-debug.el
@@ -85,10 +85,9 @@ This only takes effect if `tree-sitter-debug-jump-buttons' is non-nil."
                              (tree-sitter-debug--display-node
                               named-p type start-byte end-byte depth)))
                     [:named-p :type :start-byte :end-byte :depth]))
-          (:iterator (iter-do (item (tsc-traverse-depth-first-iterator
-                                     tree
-                                     [:named-p :type :start-byte :end-byte :depth]))
-                       (pcase-let ((`[,named-p ,type ,start-byte ,end-byte ,depth] item))
+          (:iterator (iter-do (props (tsc-traverse-depth-first-iterator
+                                      tree [:named-p :type :start-byte :end-byte :depth]))
+                       (pcase-let ((`[,named-p ,type ,start-byte ,end-byte ,depth] props))
                          (tree-sitter-debug--display-node
                           named-p type start-byte end-byte depth))))
           (:do-tree (tsc-do-tree ([named-p type start-byte end-byte depth] tree)

--- a/tests/tree-sitter-bench.el
+++ b/tests/tree-sitter-bench.el
@@ -1,0 +1,94 @@
+;;; tree-sitter-bench.el --- Benchmarks for tree-sitter.el -*- lexical-binding: t; coding: utf-8 -*-
+
+;; Copyright (C) 2019-2022  Tuấn-Anh Nguyễn
+;;
+;; Author: Tuấn-Anh Nguyễn <ubolonton@gmail.com>
+;; SPDX-License-Identifier: MIT
+
+;;; Commentary:
+
+;; Benchmarks for `tree-sitter'.
+
+;;; Code:
+
+;; Local Variables:
+;; no-byte-compile: t
+;; End:
+
+(require 'tree-sitter-tests-utils)
+
+(ert-deftest parsing::bench ()
+  (tsc-test-with c parser
+    (tsc-test-with-file "data/types.rs"
+      (let ((n 0))
+        (while (<= n 4)
+          (let ((tsc--buffer-input-chunk-size (* 1024 (expt 2 n))))
+            (garbage-collect)
+            (message "tsc-parse-chunks %6d %s" tsc--buffer-input-chunk-size
+                     (benchmark-run 10
+                         (tsc-parse-chunks parser #'tsc--buffer-input nil)))
+            (cl-incf n)))))))
+
+(ert-deftest cursor::bench ()
+  (tsc-test-lang-with-file rust "data/types.rs"
+    (require 'rust-mode)
+    (rust-mode)
+    (tree-sitter-mode)
+    (let ((props [:named-p :type :start-byte :end-byte]))
+      (dolist (n '(1 10 100))
+        (message "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~")
+        (garbage-collect)
+        (message "%10s %3d %s" :mapc n
+                 (eval `(benchmark-run-compiled ,n
+                          (tsc-traverse-mapc
+                           tsc-test-no-op
+                           tree-sitter-tree
+                           ,props))))
+        (garbage-collect)
+        (message "%10s %3d %s" :iter n
+                 (eval `(benchmark-run-compiled ,n
+                          (iter-do (_ (tsc-traverse-iter tree-sitter-tree ,props))
+                            (tsc-test-no-op)))))
+        (garbage-collect)
+        (message "%10s %3d %s" :do n
+                 (eval `(benchmark-run-compiled ,n
+                          (tsc-traverse-do ([named-p type start-byte end-byte] tree-sitter-tree)
+                            named-p type start-byte end-byte))))
+        (garbage-collect)
+        (message "%10s %3d %s" 'funcall n
+                 (eval `(benchmark-run-compiled ,(* 3429 n)
+                          (funcall tsc-test-no-op ,props 5))))))))
+
+(ert-deftest hl::bench ()
+  (tsc-test-lang-with-file rust "data/types.rs"
+    (setq tree-sitter-hl-default-patterns (tree-sitter-langs--hl-default-patterns 'rust))
+    (require 'rust-mode)
+    (rust-mode)
+    (font-lock-mode)
+    (font-lock-set-defaults)
+    (dolist (n '(1 10 100))
+      (message "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~")
+      (tree-sitter-hl-mode)
+      (garbage-collect)
+      (message "tree-sitter-hl %2d %s" n (eval `(benchmark-run-compiled ,n (font-lock-ensure))))
+      (tree-sitter-hl-mode -1)
+      (font-lock-ensure)
+      (garbage-collect)
+      (message "     font-lock %2d %s" n (eval `(benchmark-run-compiled ,n (font-lock-ensure)))))))
+
+(ert-deftest debug::bench ()
+  (tsc-test-lang-with-file rust "data/types.rs"
+    (setq tree-sitter-hl-default-patterns (tree-sitter-langs--hl-default-patterns 'rust))
+    (require 'rust-mode)
+    (rust-mode)
+    (dolist (n '(1 10 100))
+      (message "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~")
+      (dolist (tree-sitter-debug-traversal-method '(:mapc :iter :do))
+        (garbage-collect)
+        (message "%10s %3d %s" tree-sitter-debug-traversal-method n
+                 (eval `(benchmark-run-compiled ,n
+                          (progn (tree-sitter-debug-mode -1)
+                                 (tree-sitter-debug-mode)))))))))
+
+(provide 'tree-sitter-bench)
+;;; tree-sitter-bench.el ends here

--- a/tests/tree-sitter-tests-utils.el
+++ b/tests/tree-sitter-tests-utils.el
@@ -1,0 +1,140 @@
+;;; tree-sitter-tests-utils.el --- Utils for tree-sitter-tests.el -*- lexical-binding: t; coding: utf-8 -*-
+
+;; Copyright (C) 2019-2022  Tuấn-Anh Nguyễn
+;;
+;; Author: Tuấn-Anh Nguyễn <ubolonton@gmail.com>
+;; SPDX-License-Identifier: MIT
+
+;;; Commentary:
+
+;; Utils for `tree-sitter-tests'.
+
+;;; Code:
+
+(setq tsc-dyn-get-from nil)
+(require 'tree-sitter)
+(require 'tree-sitter-debug)
+
+(defvar tree-sitter-langs--testing)
+;;; Disable grammar downloading.
+(let ((tree-sitter-langs--testing t))
+  (require 'tree-sitter-langs))
+;;; Build the grammars, if necessary.
+(dolist (lang-symbol '(rust python javascript c))
+  (tree-sitter-langs-ensure lang-symbol))
+
+;; XXX: Bash grammar failed 'tree-sitter test' on Windows: 'Escaped newlines'.
+(with-demoted-errors "Failed to ensure bash grammar %s"
+  (tree-sitter-langs-ensure 'bash))
+
+(require 'ert)
+(require 'generator)
+
+(eval-when-compile
+  (require 'subr-x)
+  (require 'cl-lib))
+
+;;; ----------------------------------------------------------------------------
+;;; Helpers.
+
+(defun tsc-test-make-parser (lang-symbol)
+  "Return a new parser for LANG-SYMBOL."
+  (let ((parser (tsc-make-parser))
+        (language (tree-sitter-require lang-symbol)))
+    (tsc-set-language parser language)
+    parser))
+
+(defun tsc-test-full-path (relative-path)
+  "Return full path from project RELATIVE-PATH."
+  (concat (file-name-directory (locate-library "tree-sitter-tests.el"))
+          relative-path))
+
+(defun tsc-test-tree-sexp (sexp &optional reset)
+  "Check that the current syntax tree's sexp representation is SEXP.
+If RESET is non-nil, also do another full parse and check again."
+  (should (equal (read (tsc-tree-to-sexp tree-sitter-tree)) sexp))
+  (when reset
+    (setq tree-sitter-tree nil)
+    (tree-sitter--do-parse)
+    (tsc-test-tree-sexp sexp)))
+
+(defun tsc-test-use-lang (lang-symbol)
+  "Turn on `tree-sitter-mode' in the current buffer, using language LANG-SYMBOL."
+  (setq tree-sitter-language (tree-sitter-require lang-symbol))
+  (ignore-errors
+    (setq tree-sitter-hl-default-patterns
+          (tree-sitter-langs--hl-default-patterns lang-symbol)))
+  (add-hook 'tree-sitter-after-first-parse-hook
+            (lambda () (should (not (null tree-sitter-tree)))))
+  (tree-sitter-mode))
+
+(defun tsc--listify (x)
+  (if (listp x)
+      x
+    (list x)))
+
+(defun tsc--hl-at (pos face)
+  "Return t if text at POS is highlighted with FACE."
+  (memq face (tsc--listify (get-text-property pos 'face))))
+
+(defun tsc-test-no-op (&rest _args))
+
+(defvar tsc-test-no-op
+  (byte-compile #'tsc-test-no-op))
+
+(defun tsc-test-render-node (type named-p start-byte end-byte field depth)
+  (when named-p
+    (message "%s%s%S (%s . %s)" (make-string (* 2 depth) ?\ )
+             (if field
+                 (format "%s " field)
+               "")
+             type start-byte end-byte)))
+
+(defmacro tsc-test-with (lang-symbol var &rest body)
+  "Eval BODY with VAR bound to a new parser for LANG-SYMBOL."
+  (declare (indent 2))
+  `(let ((,var (tsc-test-make-parser ',lang-symbol)))
+     ,@body))
+
+(defmacro tsc-test-with-file (relative-path &rest body)
+  "Eval BODY in a temp buffer filled with content of the file at RELATIVE-PATH."
+  (declare (indent 1))
+  `(with-temp-buffer
+     (let ((coding-system-for-read 'utf-8))
+       (insert-file-contents (tsc-test-full-path ,relative-path)))
+     ,@body))
+
+(defmacro tsc-test-lang-with-file (lang-symbol relative-path &rest body)
+  "Eval BODY in a temp buffer filled with content of the file at RELATIVE-PATH.
+`tree-sitter-mode' is turned on, using the given language LANG-SYMBOL."
+  (declare (indent 2))
+  `(tsc-test-with-file ,relative-path
+     (tsc-test-use-lang ',lang-symbol)
+     ,@body))
+
+(defmacro tsc-test-with-advice (symbol where function &rest body)
+  "Eval BODY while advising SYMBOL with FUNCTION at WHERE."
+  (declare (indent 3))
+  `(progn
+     (advice-add ,symbol ,where ,function)
+     (unwind-protect
+         ,@body
+       (advice-remove ,symbol ,function))))
+
+(defmacro tsc-test-capture-messages (&rest body)
+  `(with-temp-buffer
+     (let ((buf (current-buffer)))
+       (tsc-test-with-advice 'message :override
+                             (lambda (fmt &rest args)
+                               (with-current-buffer buf
+                                 (insert (apply #'format-message fmt args) "\n")))
+         ,@body)
+       (with-current-buffer buf
+         (buffer-string)))))
+
+;; Local Variables:
+;; no-byte-compile: t
+;; End:
+
+(provide 'tree-sitter-tests-utils)
+;;; tree-sitter-tests-utils.el ends here

--- a/tests/tree-sitter-tests.el
+++ b/tests/tree-sitter-tests.el
@@ -374,10 +374,10 @@ source_file (1 . 20)
           (tsc-test-capture-messages
            (tsc-traverse-depth-first-native
             tree
-            (lambda (props depth)
-              (pcase-let ((`[,type ,named-p ,start-byte ,end-byte ,field] props))
+            (lambda (props)
+              (pcase-let ((`[,type ,named-p ,start-byte ,end-byte ,field ,depth] props))
                 (tsc-test-render-node type named-p start-byte end-byte field depth)))
-            [:type :named-p :start-byte :end-byte :field])))))
+            [:type :named-p :start-byte :end-byte :field :depth])))))
       (ert-info ("Generator-based traversal should work")
         (should
          (string=
@@ -385,8 +385,8 @@ source_file (1 . 20)
           (tsc-test-capture-messages
            (cl-loop for item
                     iter-by (tsc-traverse-depth-first-iterator
-                             tree [:type :named-p :start-byte :end-byte :field])
-                    do (pcase-let ((`[[,type ,named-p ,start-byte ,end-byte ,field] ,depth] item))
+                             tree [:type :named-p :start-byte :end-byte :field :depth])
+                    do (pcase-let ((`[,type ,named-p ,start-byte ,end-byte ,field ,depth] item))
                          (tsc-test-render-node type named-p start-byte end-byte field depth)))))))
       (ert-info ("Inline traversal should work")
         (should

--- a/tests/tree-sitter-tests.el
+++ b/tests/tree-sitter-tests.el
@@ -389,31 +389,31 @@ tree is held (since nodes internally reference the tree)."
         (message "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~")
         (pcase-dolist (`(,func ,msg)
                        '((tsc-traverse-depth-first-recursive
-                          "recursive")
+                          " recursive")
                          (tsc-traverse-depth-first-recursive
-                          "iterative")
+                          " iterative")
                          (tsc-traverse-depth-first-native-1
-                          " native-1")
+                          "  native-1")
                          (tsc-traverse-depth-first-native
-                          "   native")))
+                          "    native")))
           ;; (setq tsc-counter 0)
           (garbage-collect)
           (message "%s %3d %s" msg n
                    (eval `(benchmark-run-compiled ,n
                             (,func tree-sitter-tree tsc-test-no-op ,props)))))
         (garbage-collect)
-        (message " iterator %3d %s" n
+        (message "  iterator %3d %s" n
                  (eval `(benchmark-run-compiled ,n
                           (iter-do (_ (tsc-traverse-depth-first-iterator tree-sitter-tree ,props))
                             (tsc-test-no-op)))))
         (garbage-collect)
-        (message "  do-tree %3d %s" n
+        (message "   do-tree %3d %s" n
                  (eval `(benchmark-run-compiled ,n
                           (tsc-do-tree tree-sitter-tree (item ,props)
                             ;; (tsc-test-no-op)
                             ))))
         (garbage-collect)
-        (message "  funcall %3d %s" n
+        (message "   funcall %3d %s" n
                  (eval `(benchmark-run-compiled ,(* 3429 n)
                           (funcall tsc-test-no-op ,props 5))))))))
 

--- a/tests/tree-sitter-tests.el
+++ b/tests/tree-sitter-tests.el
@@ -397,7 +397,7 @@ tree is held (since nodes internally reference the tree)."
         (pcase-dolist (`(,func ,msg)
                        '((tsc-traverse-depth-first-recursive
                           " recursive")
-                         (tsc-traverse-depth-first-recursive
+                         (tsc-traverse-depth-first-iterative
                           " iterative")
                          (tsc-traverse-depth-first-native-1
                           "  native-1")
@@ -645,7 +645,7 @@ We know it should since it is the `source_file' node."
       (pcase-dolist (`(,func ,msg)
                      '((tsc-traverse-depth-first-recursive
                         "recursive")
-                       (tsc-traverse-depth-first-recursive
+                       (tsc-traverse-depth-first-iterative
                         "iterative")
                        (tsc-traverse-depth-first-native-1
                         " native-1")

--- a/tests/tree-sitter-tests.el
+++ b/tests/tree-sitter-tests.el
@@ -531,6 +531,37 @@ We know it should since it is the `source_file' node."
     (tree-sitter-debug--button-node-lookup (button-at 1))
     (should (= (point) (point-min))))))
 
+(ert-deftest debug::bench ()
+  (tsc-test-lang-with-file rust "data/types.rs"
+    (setq tree-sitter-hl-default-patterns (tree-sitter-langs--hl-default-patterns 'rust))
+    (require 'rust-mode)
+    (rust-mode)
+    (dolist (n '(1 10 100))
+      (tree-sitter-debug-mode -1)
+      (garbage-collect)
+      (message "    brute %2d %s" n
+               (eval `(benchmark-run ,n
+                        (let ((tree-sitter-debug-traverse-function
+                               #'tsc-traverse-depth-first-brute))
+                          (progn (tree-sitter-debug-mode -1)
+                                 (tree-sitter-debug-mode))))))
+      (tree-sitter-debug-mode -1)
+      (garbage-collect)
+      (message "recursive %2d %s" n
+               (eval `(benchmark-run ,n
+                        (let ((tree-sitter-debug-traverse-function
+                               #'tsc-traverse-depth-first-recursive))
+                          (progn (tree-sitter-debug-mode -1)
+                                 (tree-sitter-debug-mode))))))
+      (tree-sitter-debug-mode -1)
+      (garbage-collect)
+      (message "iterative %2d %s" n
+               (eval `(benchmark-run ,n
+                        (let ((tree-sitter-debug-traverse-function
+                               #'tsc-traverse-depth-first-iterative))
+                          (progn (tree-sitter-debug-mode -1)
+                                 (tree-sitter-debug-mode)))))))))
+
 ;; Local Variables:
 ;; no-byte-compile: t
 ;; End:

--- a/tests/tree-sitter-tests.el
+++ b/tests/tree-sitter-tests.el
@@ -212,8 +212,11 @@ tree is held (since nodes internally reference the tree)."
       (should-not (equal (tsc-node-type (tsc-current-node cursor)) 'source_file))
       (tsc-reset-cursor cursor node)
       (should (equal (tsc-node-type (tsc-current-node cursor)) 'source_file))
-      (should (equal (tsc--current-node cursor [:type] nil) [source_file]))
-      (message "->> %s" (tsc--current-node cursor [:start-byte :end-byte :type :field nil] nil)))))
+      (should (equal (tsc-current-node cursor :type) 'source_file))
+      (should (equal (tsc-current-node cursor [:start-byte :end-byte :type])
+                     `[,(point-min) ,(point-max) source_file]))
+      (should-error (tsc-current-node cursor :depth))
+      (should-error (tsc-current-node cursor [:depth])))))
 
 (ert-deftest cursor::using-without-tree ()
   (tsc-test-with rust parser

--- a/tests/tree-sitter-tests.el
+++ b/tests/tree-sitter-tests.el
@@ -11,126 +11,7 @@
 
 ;;; Code:
 
-(setq tsc-dyn-get-from nil)
-(require 'tree-sitter)
-(require 'tree-sitter-debug)
-
-(defvar tree-sitter-langs--testing)
-;;; Disable grammar downloading.
-(let ((tree-sitter-langs--testing t))
-  (require 'tree-sitter-langs))
-;;; Build the grammars, if necessary.
-(dolist (lang-symbol '(rust python javascript c))
-  (tree-sitter-langs-ensure lang-symbol))
-
-;; XXX: Bash grammar failed 'tree-sitter test' on Windows: 'Escaped newlines'.
-(with-demoted-errors "Failed to ensure bash grammar %s"
-  (tree-sitter-langs-ensure 'bash))
-
-(require 'ert)
-(require 'generator)
-
-(eval-when-compile
-  (require 'subr-x)
-  (require 'cl-lib))
-
-;;; ----------------------------------------------------------------------------
-;;; Helpers.
-
-(defun tsc-test-make-parser (lang-symbol)
-  "Return a new parser for LANG-SYMBOL."
-  (let ((parser (tsc-make-parser))
-        (language (tree-sitter-require lang-symbol)))
-    (tsc-set-language parser language)
-    parser))
-
-(defun tsc-test-full-path (relative-path)
-  "Return full path from project RELATIVE-PATH."
-  (concat (file-name-directory (locate-library "tree-sitter-tests.el"))
-          relative-path))
-
-(defun tsc-test-tree-sexp (sexp &optional reset)
-  "Check that the current syntax tree's sexp representation is SEXP.
-If RESET is non-nil, also do another full parse and check again."
-  (should (equal (read (tsc-tree-to-sexp tree-sitter-tree)) sexp))
-  (when reset
-    (setq tree-sitter-tree nil)
-    (tree-sitter--do-parse)
-    (tsc-test-tree-sexp sexp)))
-
-(defun tsc-test-use-lang (lang-symbol)
-  "Turn on `tree-sitter-mode' in the current buffer, using language LANG-SYMBOL."
-  (setq tree-sitter-language (tree-sitter-require lang-symbol))
-  (ignore-errors
-    (setq tree-sitter-hl-default-patterns
-          (tree-sitter-langs--hl-default-patterns lang-symbol)))
-  (add-hook 'tree-sitter-after-first-parse-hook
-            (lambda () (should (not (null tree-sitter-tree)))))
-  (tree-sitter-mode))
-
-(defun tsc--listify (x)
-  (if (listp x)
-      x
-    (list x)))
-
-(defun tsc--hl-at (pos face)
-  "Return t if text at POS is highlighted with FACE."
-  (memq face (tsc--listify (get-text-property pos 'face))))
-
-(defun tsc-test-no-op (&rest _args))
-
-(defvar tsc-test-no-op
-  (byte-compile #'tsc-test-no-op))
-
-(defun tsc-test-render-node (type named-p start-byte end-byte field depth)
-  (when named-p
-    (message "%s%s%S (%s . %s)" (make-string (* 2 depth) ?\ )
-             (if field
-                 (format "%s " field)
-               "")
-             type start-byte end-byte)))
-
-(defmacro tsc-test-with (lang-symbol var &rest body)
-  "Eval BODY with VAR bound to a new parser for LANG-SYMBOL."
-  (declare (indent 2))
-  `(let ((,var (tsc-test-make-parser ',lang-symbol)))
-     ,@body))
-
-(defmacro tsc-test-with-file (relative-path &rest body)
-  "Eval BODY in a temp buffer filled with content of the file at RELATIVE-PATH."
-  (declare (indent 1))
-  `(with-temp-buffer
-     (let ((coding-system-for-read 'utf-8))
-       (insert-file-contents (tsc-test-full-path ,relative-path)))
-     ,@body))
-
-(defmacro tsc-test-lang-with-file (lang-symbol relative-path &rest body)
-  "Eval BODY in a temp buffer filled with content of the file at RELATIVE-PATH.
-`tree-sitter-mode' is turned on, using the given language LANG-SYMBOL."
-  (declare (indent 2))
-  `(tsc-test-with-file ,relative-path
-     (tsc-test-use-lang ',lang-symbol)
-     ,@body))
-
-(defmacro tsc-test-with-advice (symbol where function &rest body)
-  "Eval BODY while advising SYMBOL with FUNCTION at WHERE."
-  (declare (indent 3))
-  `(progn
-     (advice-add ,symbol ,where ,function)
-     (unwind-protect
-         ,@body
-       (advice-remove ,symbol ,function))))
-
-(defmacro tsc-test-capture-messages (&rest body)
-  `(with-temp-buffer
-     (let ((buf (current-buffer)))
-       (tsc-test-with-advice 'message :override
-                             (lambda (fmt &rest args)
-                               (with-current-buffer buf
-                                 (insert (apply #'format-message fmt args) "\n")))
-         ,@body)
-       (with-current-buffer buf
-         (buffer-string)))))
+(require 'tree-sitter-tests-utils)
 
 ;;; ----------------------------------------------------------------------------
 ;;; Tests.
@@ -211,18 +92,6 @@ If RESET is non-nil, also do another full parse and check again."
             (should (equal [] (tsc-changed-ranges old-tree tree))))
           (ert-info ("Incremental parsing should be faster than initial")
             (should (> (car initial) (car reparse)))))))))
-
-(ert-deftest parsing::bench ()
-  (tsc-test-with c parser
-    (tsc-test-with-file "data/types.rs"
-      (let ((n 0))
-        (while (<= n 4)
-          (let ((tsc--buffer-input-chunk-size (* 1024 (expt 2 n))))
-            (garbage-collect)
-            (message "tsc-parse-chunks %6d %s" tsc--buffer-input-chunk-size
-                     (benchmark-run 10
-                         (tsc-parse-chunks parser #'tsc--buffer-input nil)))
-            (cl-incf n)))))))
 
 (ert-deftest minor-mode::basic-editing ()
   (with-temp-buffer
@@ -395,36 +264,6 @@ source_file (1 . 20)
           (tsc-test-capture-messages
            (tsc-traverse-do ([type named-p start-byte end-byte field depth] tree)
              (tsc-test-render-node type named-p start-byte end-byte field depth)))))))))
-
-(ert-deftest cursor::bench ()
-  (tsc-test-lang-with-file rust "data/types.rs"
-    (require 'rust-mode)
-    (rust-mode)
-    (tree-sitter-mode)
-    (let ((props [:named-p :type :start-byte :end-byte]))
-      (dolist (n '(1 10 100))
-        (message "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~")
-        (garbage-collect)
-        (message "%10s %3d %s" :mapc n
-                 (eval `(benchmark-run-compiled ,n
-                          (tsc-traverse-mapc
-                           tsc-test-no-op
-                           tree-sitter-tree
-                           ,props))))
-        (garbage-collect)
-        (message "%10s %3d %s" :iter n
-                 (eval `(benchmark-run-compiled ,n
-                          (iter-do (_ (tsc-traverse-iter tree-sitter-tree ,props))
-                            (tsc-test-no-op)))))
-        (garbage-collect)
-        (message "%10s %3d %s" :do n
-                 (eval `(benchmark-run-compiled ,n
-                          (tsc-traverse-do ([named-p type start-byte end-byte] tree-sitter-tree)
-                            named-p type start-byte end-byte))))
-        (garbage-collect)
-        (message "%10s %3d %s" 'funcall n
-                 (eval `(benchmark-run-compiled ,(* 3429 n)
-                          (funcall tsc-test-no-op ,props 5))))))))
 
 (ert-deftest conversion::position<->tsc-point ()
   (tsc-test-with-file "tree-sitter-tests.el"
@@ -602,23 +441,6 @@ source_file (1 . 20)
     (font-lock-ensure)
     (should (tsc--hl-at 6 'tree-sitter-hl-face:function))))
 
-(ert-deftest hl::bench ()
-  (tsc-test-lang-with-file rust "data/types.rs"
-    (setq tree-sitter-hl-default-patterns (tree-sitter-langs--hl-default-patterns 'rust))
-    (require 'rust-mode)
-    (rust-mode)
-    (font-lock-mode)
-    (font-lock-set-defaults)
-    (dolist (n '(1 10 100))
-      (message "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~")
-      (tree-sitter-hl-mode)
-      (garbage-collect)
-      (message "tree-sitter-hl %2d %s" n (eval `(benchmark-run-compiled ,n (font-lock-ensure))))
-      (tree-sitter-hl-mode -1)
-      (font-lock-ensure)
-      (garbage-collect)
-      (message "     font-lock %2d %s" n (eval `(benchmark-run-compiled ,n (font-lock-ensure)))))))
-
 (ert-deftest debug::jump ()
   "Test if the first button takes us to the beginning of the file.
 We know it should since it is the `source_file' node."
@@ -631,20 +453,6 @@ We know it should since it is the `source_file' node."
     (switch-to-buffer tree-sitter-debug--tree-buffer nil t)
     (tree-sitter-debug--button-node-lookup (button-at 1))
     (should (= (point) (point-min))))))
-
-(ert-deftest debug::bench ()
-  (tsc-test-lang-with-file rust "data/types.rs"
-    (setq tree-sitter-hl-default-patterns (tree-sitter-langs--hl-default-patterns 'rust))
-    (require 'rust-mode)
-    (rust-mode)
-    (dolist (n '(1 10 100))
-      (message "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~")
-      (dolist (tree-sitter-debug-traversal-method '(:mapc :iter :do))
-        (garbage-collect)
-        (message "%10s %3d %s" tree-sitter-debug-traversal-method n
-                 (eval `(benchmark-run-compiled ,n
-                          (progn (tree-sitter-debug-mode -1)
-                                 (tree-sitter-debug-mode)))))))))
 
 ;; Local Variables:
 ;; no-byte-compile: t


### PR DESCRIPTION
- Add APIs to efficiently traverse the syntax tree: `tsc-traverse-do`, `tsc-traverse-mapc`, `tsc-traverse-iter`. The traversal is depth-first pre-order.
- Improve syntax tree rendering's performance in `tree-sitter-debug`.
- Add optional params `props` and `output` to `tsc-current-node`, which allows retrieving node properties, instead of the node object itself. This enables performance optimizations in uses cases that deal with a large number of nodes.
