### PR TITLE
Add tree-sitter-mode lighter

### DIFF
--- a/lisp/tree-sitter.el
+++ b/lisp/tree-sitter.el
@@ -55,6 +55,11 @@ Use this to enable other minor modes that depends on the syntax tree."
   :type '(alist :key-type symbol
                 :value-type symbol))
 
+(defcustom tree-sitter-mode-lighter " tree-sitter"
+  "Lighter for command `tree-sitter-mode'."
+  :group 'tree-sitter
+  :type '(string :tag "Lighter"))
+
 (defvar-local tree-sitter-tree nil
   "Tree-sitter syntax tree.")
 
@@ -184,7 +189,7 @@ signal an error."
 (define-minor-mode tree-sitter-mode
   "Minor mode that keeps an up-to-date syntax tree using incremental parsing."
   :init-value nil
-  :lighter " tree-sitter"
+  :lighter tree-sitter-mode-lighter
   :after-hook (when tree-sitter-mode
                 (unless tree-sitter-tree
                   (tree-sitter--do-parse)


### PR DESCRIPTION
Add new, customizable, variable `tree-sitter-mode-lighter`.  It lets the user to
customize `tree-sitter-mode` lighter in `mode-line` and disable it by setting it to
an empty string.

This is very useful for people that do not use packages like **diminish**, because
Emacs has a built-in way of doing that.
