### PR TITLE
Added support for OpenBSD

### DIFF
--- a/bin/env.bash
+++ b/bin/env.bash
@@ -5,6 +5,8 @@ if [[ $system == "Linux" ]]; then
     ext="so"
 elif [[ $system == "Darwin" ]]; then
     ext="dylib"
+elif [[ $system == "OpenBSD" ]]; then
+    ext='so'
 else
     echo "Unsupported system: $system"
     exit 1


### PR DESCRIPTION
Since the dynamic client is compiled by hand and not automatically fetched by EMACS, all that was changed in order to allow cargo to build was `env.bash`. The client was built successfully, but not installed in the system with `cargo install --path ./`. It was unclear whether this additional step was needed or not. 

After completion of this pull request, I will perform a PR in my forked repo, and then instruct straight to install elisp-tree-sitter from there. This should allow me to then go into the repo and compile the client again by hand for testing.