### PR TITLE
[fix] `tsc-dyn-get--recorded-version`: support new DYN-VERSION syntax

### DIFF
--- a/core/tsc-dyn-get.el
+++ b/core/tsc-dyn-get.el
@@ -105,6 +105,9 @@ this to nil."
       (with-temp-buffer
         (let ((coding-system-for-read 'utf-8))
           (insert-file-contents tsc-dyn-get--version-file)
+          (goto-char (point-min))
+          (when (re-search-forward "@" nil t)
+            (delete-region (point-min) (point)))
           (buffer-string))))))
 
 (defun tsc-dyn-get--loaded-version ()


### PR DESCRIPTION
Previously, a tree-sitter `DYN-VERSION` file used to look like this: <pre>0.18.0</pre> (with no final newlines). Now it may look like this:<pre>emacs-tree-sitter@0.18.0</pre> (still sans final newlines).

In `tsc-dyn-get--recorded-version`, support both formats by erasing everything up to and including first `@`