### PR TITLE
Fix error on NetBSD

### DIFF
--- a/bin/env.bash
+++ b/bin/env.bash
@@ -1,7 +1,7 @@
 set -euo pipefail
 
 system=$(uname)
-if [[ $system == "Linux" ]]; then
+if [[ $system == "Linux" ]] || [[ $system == "NetBSD" ]]; then
     ext="so"
 elif [[ $system == "Darwin" ]]; then
     ext="dylib"

--- a/core/tsc-dyn-get.el
+++ b/core/tsc-dyn-get.el
@@ -72,7 +72,7 @@ this to nil."
   (pcase system-type
     ('windows-nt "dll")
     ('darwin "dylib")
-    ((or 'gnu 'gnu/linux 'gnu/kfreebsd) "so")
+    ((or 'gnu 'gnu/linux 'gnu/kfreebsd 'berkeley-unix) "so")
     ((or 'ms-dos 'cygwin) (error "Unsupported system-type %s" system-type))
     (_ "so")))
 

--- a/lisp/tree-sitter-load.el
+++ b/lisp/tree-sitter-load.el
@@ -32,7 +32,7 @@ See `tree-sitter-require'.")
   (pcase system-type
     ;; The CLI tool outputs `.so', but `.dylib' is more sensible on macOS.
     ('darwin (list ".dylib" ".so"))
-    ('gnu/linux (list ".so"))
+    ((or 'gnu 'gnu/linux 'gnu/kfreebsd 'berkeley-unix) "so")
     ('windows-nt (list ".dll"))
     (_ (error "Unsupported system-type %s" system-type)))
   "List of suffixes for shared libraries that define tree-sitter languages.")


### PR DESCRIPTION
I'm running emacs from git, and I have tree-sitter-lang installed from MELPA (perhaps I don't need this any longer since emacs has native tree-sitter support now). From `list-packages`:
```
...
tree-sitter                    20220212.1632  installed             Incremental parsing system
...
tree-sitter-langs              20230622.719   installed             Grammar bundle for tree-sitter
...
```
Anyway, while upgrading packages I noticed:
```
Compiling file /home/wiz/.emacs.d/elpa/tree-sitter-langs-20230622.719/tree-sitter-langs.el at Fri Jun 23 21:37:44 2023
tree-sitter-langs.el:40:2: Error: Unsupported system-type berkeley-unix
````
Line 40 in that file is just
```
(require 'tree-sitter)
```
so I dug deeper and found the problematic code in this repository.
I then tried to build it using GNU make and found another problem.
The build now proceeds until `cask` is used, which I don't have installed.
Please check if the diffs look sane and merge them if appropriate.
Thanks!