### PR TITLE
fix: Make button without newline

### DIFF
--- a/lisp/tree-sitter-debug.el
+++ b/lisp/tree-sitter-debug.el
@@ -61,13 +61,14 @@ This only takes effect if `tree-sitter-debug-jump-buttons' is non-nil."
   "Display NODE that appears at the given DEPTH in the syntax tree."
   (when named-p
     (insert (make-string (* 2 depth) ?\ ))
-    (let ((node-text (format "%s:\n" type)))
+    (let ((node-text (format "%s:" type)))
       (if tree-sitter-debug-jump-buttons
           (insert-button node-text
                          'action 'tree-sitter-debug--button-node-lookup
                          'follow-link t
                          'points-to `(,start-byte . ,end-byte))
-        (insert node-text)))))
+        (insert node-text))
+      (insert "\n"))))
 
 (defvar tree-sitter-debug-traversal-method :mapc)
 


### PR DESCRIPTION
| Before | After |
|---|---|
| ![2023-09-08 15 36 20](https://github.com/emacs-tree-sitter/elisp-tree-sitter/assets/8685505/53a7399a-8dd2-43c0-ba63-aa8e85a4b420) | ![2023-09-08 15 35 55](https://github.com/emacs-tree-sitter/elisp-tree-sitter/assets/8685505/3be73da7-12a0-4fbf-bd07-76c3732295e5) |