### PR TITLE
chore: Remove Cask related files

### DIFF
--- a/.github/script/setup-cask
+++ b/.github/script/setup-cask
@@ -1,4 +1,0 @@
-#!/usr/bin/env bash
-
-git clone -b github-actions https://github.com/ubolonton/cask "$HOME"/.cask
-echo "$HOME/.cask/bin" >> "$GITHUB_PATH"

--- a/.github/script/setup-cask.ps1
+++ b/.github/script/setup-cask.ps1
@@ -1,2 +1,0 @@
-git clone -b github-actions https://github.com/ubolonton/cask "$env:UserProfile\.cask"
-echo "$env:UserProfile\.cask\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,7 +26,7 @@ jobs:
             emacs-version: '27.2'
             ext: dylib
             target: aarch64-apple-darwin
-          - os: ubuntu-18.04
+          - os: ubuntu-20.04
             emacs-version: '27.2'
             ext: so
             host: x86_64-unknown-linux-gnu
@@ -94,7 +94,7 @@ jobs:
 
   publish-binaries:
     needs: build
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
       - uses: jcs090218/setup-emacs@master
         with:
@@ -127,7 +127,7 @@ jobs:
         include:
           - os: macos-12
             emacs-version: '27.2'
-          - os: ubuntu-18.04
+          - os: ubuntu-20.04
             emacs-version: '27.2'
           # XXX: Fails on CI, but not locally (Windows 10) with
           # :value 2 :fail-reason "did not signal an error"
@@ -154,7 +154,7 @@ jobs:
 
   publish-melpa:
     needs: integ
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v4
 

--- a/Cask
+++ b/Cask
@@ -1,9 +1,0 @@
-(package-file "lisp/tree-sitter.el")
-
-(files "lisp/*.el")
-
-(source melpa)
-
-(development
- (depends-on "rust-mode")
- (depends-on "async"))

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ If you want to hack on `emacs-tree-sitter` itself, see the next section instead.
 
 - Clone this repo with the `--recursive` flag.
 - Add 3 of its directories to `load-path`: `core/`, `lisp/` and `langs/`.
-- Install [cask](https://cask.readthedocs.io).
+- Install [eask](https://emacs-eask.github.io/).
 - Run `bin/setup`.
 
 If you want to hack on the high-level features (in Lisp) only:

--- a/core/Cask
+++ b/core/Cask
@@ -1,9 +1,0 @@
-(package-file "tsc.el")
-
-(files "*.el"
-       "tsc-dyn.dylib"
-       "tsc-dyn.so"
-       "tsc-dyn.dll"
-       "Cargo.toml"
-       "Cargo.lock"
-       "src")


### PR DESCRIPTION
No longer using Cask to build; therefore, remove it.