### PR TITLE
fix DYN_VERSION from build

### DIFF
--- a/core/tsc-dyn-get.el
+++ b/core/tsc-dyn-get.el
@@ -183,10 +183,10 @@ This function records the downloaded version in the manifest
        ,@body)))
 
 (defun tsc-dyn-get--build-version ()
-  "Return the dynamic module's version after asking 'cargo'."
+  "Return the dynamic module's version after asking `cargo'."
   (thread-first (shell-command-to-string "cargo pkgid")
     string-trim
-    (split-string "\[#:\]")
+    (split-string "\[#:@\]")
     last car))
 
 ;; TODO: Remove this when cargo allows specifying output file name.


### PR DESCRIPTION
Output of `cargo pkgid` seems to be `file://HOMEDIR/.emacs.d/straight/build/tsc#emacs-tree-sitter@0.18.0` now.